### PR TITLE
Add EIA Bulk Electricity data archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Lastly, you need to:
 
 * Add archive metadata for the new dataset in the `zs/metadata.py` module. This
   includes creating a UUID (universally unique identifier) for the data. UUIDs are
-  used to uniquely distinguish the archive prior to the creation of a DOI. You can
-  create one with free online UUID generators.
+  used to uniquely distinguish the archive prior to the creation of a DOI. You can do
+  this using the `uuid.uuid4()` function that is part of the Python standard library.
 * Add the chosen deposition name to this list of acceptable names output with the
   `zenodo_store --help` flag. See `parse_main()` in `zs.cli.py`.
 * Add specifications for your new deposition in the `archive_selection()` function also

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip>=21.0,<22
+  - pip>=21.0,<23
   - python>=3.10,<3.11
   - tox>=3.24,<4
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools<64",
+    "setuptools<66",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/pudl_zenodo_storage/__init__.py
+++ b/src/pudl_zenodo_storage/__init__.py
@@ -6,6 +6,7 @@ import pudl_zenodo_storage.frictionless.eia860
 import pudl_zenodo_storage.frictionless.eia860m
 import pudl_zenodo_storage.frictionless.eia861
 import pudl_zenodo_storage.frictionless.eia923
+import pudl_zenodo_storage.frictionless.eia_bulk_elec
 import pudl_zenodo_storage.frictionless.epacamd_eia
 import pudl_zenodo_storage.frictionless.epacems
 import pudl_zenodo_storage.frictionless.ferc1

--- a/src/pudl_zenodo_storage/frictionless/eia_bulk_elec.py
+++ b/src/pudl_zenodo_storage/frictionless/eia_bulk_elec.py
@@ -1,4 +1,4 @@
-"""Datapackage details specific to the EPA CAMD to EIA Crosswalk."""
+"""Datapackage details specific to the EIA Bulk Electricity archives."""
 
 from pudl.metadata.classes import DataSource
 from pudl_zenodo_storage.frictionless.core import DataPackage, minimal_archiver
@@ -6,7 +6,7 @@ from pudl_zenodo_storage.frictionless.core import DataPackage, minimal_archiver
 
 def datapackager(dfiles):
     """
-    Produce the datapackage json for the epacamd_eia archive.
+    Produce the datapackage json for the eia_bulk_elec archive.
 
     Args:
         dfiles: iterable of file descriptors, as expected from Zenodo.
@@ -17,7 +17,7 @@ def datapackager(dfiles):
         https://frictionlessdata.io/specs/data-package/
     """
     return DataPackage.from_resource_archiver(
-        DataSource.from_id("epacamd_eia"),
+        DataSource.from_id("eia_bulk_elec"),
         dfiles,
         minimal_archiver,
     ).to_raw_datapackage_dict()

--- a/src/pudl_zenodo_storage/zs/core.py
+++ b/src/pudl_zenodo_storage/zs/core.py
@@ -9,7 +9,7 @@ import semantic_version
 class ZenodoStorage:
     """Thin interface to store data with zenodo.org via their API."""
 
-    def __init__(self, key, testing=False, verbose=False, loglevel="WARNING"):
+    def __init__(self, key, testing=False, verbose=True, loglevel="WARNING"):
         """
         Prepare the ZenodoStorage interface.
 

--- a/src/pudl_zenodo_storage/zs/metadata.py
+++ b/src/pudl_zenodo_storage/zs/metadata.py
@@ -1,9 +1,21 @@
 """Metadata for Zenodo depositions archiving PUDL raw input data."""
-
-
 from pudl.metadata.classes import Contributor, DataSource
 
-pudl_description = """
+UUIDS: dict[str, str] = {
+    "censusdp1tract": "beb36017-3fca-49be-a93a-7298f30ca3a3",
+    "eia860": "a93cdabd-706f-48c7-ae02-4463dacf1419",
+    "eia860m": "863ba550-1faa-11eb-8dfb-a45e60b93f07",
+    "eia861": "70999ef2-50e9-47ae-a4f6-5d69e6ff98d1",
+    "eia923": "53831f63-fa82-475a-bef4-5b5f0b7c41a4",
+    "eia_bulk_elec": "c288a5fe-1ff5-442d-a48e-7d56395bf72d",
+    "epacamd_eia": "40696588-d6ee-11ec-abb9-34363bce6e4c",
+    "epacems": "8bd99e7d-b11a-4bd1-8af0-bccf984dcc43",
+    "ferc1": "d3d91c87-c595-49d5-a7f3-e5f5669c8306",
+    "ferc2": "894a87fd-cc94-46d1-903a-44be6e77d450",
+    "ferc714": "f31f0894-639e-4bc2-9b7f-8a84713bcc87",
+}
+
+PUDL_DESCRIPTION = """
 <p>This archive contains raw input data for the Public Utility Data Liberation (PUDL)
 software developed by <a href="https://catalyst.coop">Catalyst Cooperative</a>. It is
 organized into <a href="https://specs.frictionlessdata.io/data-package/">Frictionless
@@ -35,60 +47,21 @@ def _parse_contributor_metadata(
     return zenodo_cont_list
 
 
-def _generate_metadata(data_source_id, data_source_uuid):
-
+def generate_metadata(data_source_id: str) -> dict[str, str]:
+    """Construct the metadata required for a Zenodo deposition."""
     data_source = DataSource.from_id(data_source_id)
 
     return {
         "title": f"PUDL Raw {data_source.title}",
         "language": "eng",
         "upload_type": "dataset",
-        "description": f"<p>{data_source.description} Archived from\n"
-        f'<a href="{data_source.path}">{data_source.path}</a></p>'
-        f"{pudl_description}",
+        "description": (
+            f"<p>{data_source.description} Archived from\n"
+            f'<a href="{data_source.path}">{data_source.path}</a></p>'
+            f"{PUDL_DESCRIPTION}"
+        ),
         "creators": _parse_contributor_metadata(data_source.contributors),
         "access_right": "open",
         "license": data_source.license_raw.name,
-        "keywords": [*data_source.keywords, data_source_uuid],
+        "keywords": [*data_source.keywords, UUIDS[data_source_id]],
     }
-
-
-# Unaltered Eia860 archive.
-eia860_uuid = "a93cdabd-706f-48c7-ae02-4463dacf1419"
-eia860 = _generate_metadata("eia860", eia860_uuid)
-
-# Unaltered EIA860M archive.
-eia860m_uuid = "863ba550-1faa-11eb-8dfb-a45e60b93f07"
-eia860m = _generate_metadata("eia860m", eia860m_uuid)
-
-# Unaltered Eia861 archive.
-eia861_uuid = "70999ef2-50e9-47ae-a4f6-5d69e6ff98d1"
-eia861 = _generate_metadata("eia861", eia861_uuid)
-
-# Unaltered Eia923 archive.
-eia923_uuid = "53831f63-fa82-475a-bef4-5b5f0b7c41a4"
-eia923 = _generate_metadata("eia923", eia923_uuid)
-
-# Unaltered EPA CEMS archive
-epacems_uuid = "8bd99e7d-b11a-4bd1-8af0-bccf984dcc43"
-epacems = _generate_metadata("epacems", epacems_uuid)
-
-# Unaltered EPACEMS-EIA Crosswalk archive.
-epacamd_eia_uuid = "40696588-d6ee-11ec-abb9-34363bce6e4c"
-epacamd_eia = _generate_metadata("epacamd_eia", epacamd_eia_uuid)
-
-# For the unaltered Ferc1 archive.
-ferc1_uuid = "d3d91c87-c595-49d5-a7f3-e5f5669c8306"
-ferc1 = _generate_metadata("ferc1", ferc1_uuid)
-
-# For the unaltered Ferc2 archive.
-ferc2_uuid = "894a87fd-cc94-46d1-903a-44be6e77d450"
-ferc2 = _generate_metadata("ferc2", ferc2_uuid)
-
-# Unaltered Ferc714 archive.
-ferc714_uuid = "f31f0894-639e-4bc2-9b7f-8a84713bcc87"
-ferc714 = _generate_metadata("ferc714", ferc714_uuid)
-
-# For the census archive.
-censusdp1tract_uuid = "beb36017-3fca-49be-a93a-7298f30ca3a3"
-censusdp1tract = _generate_metadata("censusdp1tract", censusdp1tract_uuid)


### PR DESCRIPTION
Mainly: add the necessary metadata and functions to produce a Zenodo datapackage archive for the bulk EIA Electricity data.

Also a little house cleaning:

* Standardize the construction of a selected archive in the CLI module rather than having a bunch of if statemnts.
* Remove the verbose option and always send logging output to stdout.
* In the zs.metadata module, get remove the pre-construction of metadata contents, so they can be dynamically constructed using generate_metadata(). Instead just store a dictionary of the UUIDs so they can be looked up by data source.

In the service of closing https://github.com/catalyst-cooperative/pudl/issues/1763