### PR TITLE
Xbrl integration

### DIFF
--- a/src/pudl_zenodo_storage/__init__.py
+++ b/src/pudl_zenodo_storage/__init__.py
@@ -11,6 +11,8 @@ import pudl_zenodo_storage.frictionless.epacamd_eia
 import pudl_zenodo_storage.frictionless.epacems
 import pudl_zenodo_storage.frictionless.ferc1
 import pudl_zenodo_storage.frictionless.ferc2
+import pudl_zenodo_storage.frictionless.ferc6
+import pudl_zenodo_storage.frictionless.ferc60
 import pudl_zenodo_storage.frictionless.ferc714
 import pudl_zenodo_storage.frictionless.licenses
 import pudl_zenodo_storage.zs.core

--- a/src/pudl_zenodo_storage/frictionless/core.py
+++ b/src/pudl_zenodo_storage/frictionless/core.py
@@ -128,7 +128,7 @@ def annual_archive_resource(name, url, size, md5_hash, **extra_parts):
         url (str): url to download the file from Zenodo.
         size (int): size in bytes.
         md5_hash (str): the md5 checksum of the file.
-        extra_parts (str): extra partitions to add to resource descriptor.
+        extra_parts (dict): extra partitions to add to resource descriptor.
 
     Returns:
         dict: a frictionless data package resource descriptor, per

--- a/src/pudl_zenodo_storage/frictionless/core.py
+++ b/src/pudl_zenodo_storage/frictionless/core.py
@@ -119,7 +119,7 @@ class DataPackage(BaseModel):
         return descriptor
 
 
-def annual_archive_resource(name, url, size, md5_hash):
+def annual_archive_resource(name, url, size, md5_hash, **extra_parts):
     """
     Produce the resource descriptor for a single file.
 
@@ -128,6 +128,7 @@ def annual_archive_resource(name, url, size, md5_hash):
         url (str): url to download the file from Zenodo.
         size (int): size in bytes.
         md5_hash (str): the md5 checksum of the file.
+        extra_parts (str): extra partitions to add to resource descriptor.
 
     Returns:
         dict: a frictionless data package resource descriptor, per
@@ -150,13 +151,39 @@ def annual_archive_resource(name, url, size, md5_hash):
         "path": url,
         "remote_url": url,
         "title": title,
-        "parts": {"year": year},
+        "parts": {"year": year, **extra_parts},
         "encoding": "utf-8",
         "mediatype": mt,
         "bytes": size,
         "hash": md5_hash,
         "format": file_format,
     }
+
+
+def ferc_annual_archive_resource(name, url, size, md5_hash):
+    """
+    Produce the resource descriptor for a single file.
+
+    FERC filers can resubmit past years in XBRL format. This means that
+    there are years with both DBF and XBRL data. These will be saved in
+    different archives, and an extra partition is added to the resource
+    descriptor to indicate which data is contianed in each archive.
+
+    Args:
+        name (str): file name: must include a 4 digit year, and no other 4 digits.
+        url (str): url to download the file from Zenodo.
+        size (int): size in bytes.
+        md5_hash (str): the md5 checksum of the file.
+
+    Returns:
+        dict: a frictionless data package resource descriptor, per
+        https://frictionlessdata.io/specs/data-resource/
+
+    """
+    # Check file name to see if it contains XBRL data
+    data_format = "XBRL" if "xbrl" in name else "DBF"
+
+    return annual_archive_resource(name, url, size, md5_hash, data_format=data_format)
 
 
 def archive_resource_year_month(name, url, size, md5_hash):

--- a/src/pudl_zenodo_storage/frictionless/ferc1.py
+++ b/src/pudl_zenodo_storage/frictionless/ferc1.py
@@ -1,7 +1,10 @@
 """Provide datapackage details specific to the FERC Form 1 archives."""
 
 from pudl.metadata.classes import DataSource
-from pudl_zenodo_storage.frictionless.core import DataPackage, annual_archive_resource
+from pudl_zenodo_storage.frictionless.core import (
+    DataPackage,
+    ferc_annual_archive_resource,
+)
 
 
 def datapackager(dfiles):
@@ -18,5 +21,5 @@ def datapackager(dfiles):
 
     """
     return DataPackage.from_resource_archiver(
-        DataSource.from_id("ferc1"), dfiles, annual_archive_resource
+        DataSource.from_id("ferc1"), dfiles, ferc_annual_archive_resource
     ).to_raw_datapackage_dict()

--- a/src/pudl_zenodo_storage/frictionless/ferc2.py
+++ b/src/pudl_zenodo_storage/frictionless/ferc2.py
@@ -1,7 +1,10 @@
 """Provide datapackage details specific to the FERC Form 2 archives."""
 
 from pudl.metadata.classes import DataSource
-from pudl_zenodo_storage.frictionless.core import DataPackage, annual_archive_resource
+from pudl_zenodo_storage.frictionless.core import (
+    DataPackage,
+    ferc_annual_archive_resource,
+)
 
 
 def datapackager(dfiles):
@@ -18,5 +21,5 @@ def datapackager(dfiles):
 
     """
     return DataPackage.from_resource_archiver(
-        DataSource.from_id("ferc2"), dfiles, annual_archive_resource
+        DataSource.from_id("ferc2"), dfiles, ferc_annual_archive_resource
     ).to_raw_datapackage_dict()

--- a/src/pudl_zenodo_storage/frictionless/ferc6.py
+++ b/src/pudl_zenodo_storage/frictionless/ferc6.py
@@ -1,7 +1,10 @@
 """Provide datapackage details specific to the FERC Form 6 archives."""
 
 from pudl.metadata.classes import DataSource
-from pudl_zenodo_storage.frictionless.core import DataPackage, annual_archive_resource
+from pudl_zenodo_storage.frictionless.core import (
+    DataPackage,
+    ferc_annual_archive_resource,
+)
 
 
 def datapackager(dfiles):
@@ -18,5 +21,5 @@ def datapackager(dfiles):
 
     """
     return DataPackage.from_resource_archiver(
-        DataSource.from_id("ferc6"), dfiles, annual_archive_resource
+        DataSource.from_id("ferc6"), dfiles, ferc_annual_archive_resource
     ).to_raw_datapackage_dict()

--- a/src/pudl_zenodo_storage/frictionless/ferc6.py
+++ b/src/pudl_zenodo_storage/frictionless/ferc6.py
@@ -1,0 +1,22 @@
+"""Provide datapackage details specific to the FERC Form 6 archives."""
+
+from pudl.metadata.classes import DataSource
+from pudl_zenodo_storage.frictionless.core import DataPackage, annual_archive_resource
+
+
+def datapackager(dfiles):
+    """
+    Produce the datapackage json for the ferc6 archival collection.
+
+    Args:
+        dfiles: iterable of file descriptors, as expected from Zenodo.
+            https://developers.zenodo.org/#deposition-files
+
+    Returns:
+        dict: fields suited to the frictionless datapackage spec
+        https://frictionlessdata.io/specs/data-package/
+
+    """
+    return DataPackage.from_resource_archiver(
+        DataSource.from_id("ferc6"), dfiles, annual_archive_resource
+    ).to_raw_datapackage_dict()

--- a/src/pudl_zenodo_storage/frictionless/ferc60.py
+++ b/src/pudl_zenodo_storage/frictionless/ferc60.py
@@ -1,7 +1,10 @@
 """Provide datapackage details specific to the FERC Form 60 archives."""
 
 from pudl.metadata.classes import DataSource
-from pudl_zenodo_storage.frictionless.core import DataPackage, annual_archive_resource
+from pudl_zenodo_storage.frictionless.core import (
+    DataPackage,
+    ferc_annual_archive_resource,
+)
 
 
 def datapackager(dfiles):
@@ -18,5 +21,5 @@ def datapackager(dfiles):
 
     """
     return DataPackage.from_resource_archiver(
-        DataSource.from_id("ferc60"), dfiles, annual_archive_resource
+        DataSource.from_id("ferc60"), dfiles, ferc_annual_archive_resource
     ).to_raw_datapackage_dict()

--- a/src/pudl_zenodo_storage/frictionless/ferc60.py
+++ b/src/pudl_zenodo_storage/frictionless/ferc60.py
@@ -1,0 +1,22 @@
+"""Provide datapackage details specific to the FERC Form 60 archives."""
+
+from pudl.metadata.classes import DataSource
+from pudl_zenodo_storage.frictionless.core import DataPackage, annual_archive_resource
+
+
+def datapackager(dfiles):
+    """
+    Produce the datapackage json for the ferc60 archival collection.
+
+    Args:
+        dfiles: iterable of file descriptors, as expected from Zenodo.
+            https://developers.zenodo.org/#deposition-files
+
+    Returns:
+        dict: fields suited to the frictionless datapackage spec
+        https://frictionlessdata.io/specs/data-package/
+
+    """
+    return DataPackage.from_resource_archiver(
+        DataSource.from_id("ferc60"), dfiles, annual_archive_resource
+    ).to_raw_datapackage_dict()

--- a/src/pudl_zenodo_storage/frictionless/ferc714.py
+++ b/src/pudl_zenodo_storage/frictionless/ferc714.py
@@ -1,7 +1,12 @@
 """Provide datapackage details specific to the Ferc Form 714 archives."""
+import re
 
 from pudl.metadata.classes import DataSource
-from pudl_zenodo_storage.frictionless.core import DataPackage, minimal_archiver
+from pudl_zenodo_storage.frictionless.core import (
+    DataPackage,
+    annual_archive_resource,
+    minimal_archiver,
+)
 
 
 def datapackager(dfiles):
@@ -18,5 +23,31 @@ def datapackager(dfiles):
 
     """
     return DataPackage.from_resource_archiver(
-        DataSource.from_id("ferc714"), dfiles, minimal_archiver
+        DataSource.from_id("ferc714"), dfiles, archive_714
     ).to_raw_datapackage_dict()
+
+
+def archive_714(name: str, url: str, size: int, md5_hash: str):
+    """Archiver wrapper for FERC 714 data.
+
+    Historical DBF data is archived in a single zip file across all years. New XBRL
+    data is archived in annual files. This will check each file name, and use the
+    appropriate archiver.
+
+    Args:
+        name: file name
+        url: url to download the file from Zenodo.
+        size: size in bytes.
+        md5_hash: the md5 checksum of the file.
+
+    Returns:
+        dict: a frictionless data package resource descriptor, per
+        https://frictionlessdata.io/specs/data-resource/
+    """
+    # Check if year is in filename (minimum year is 2000)
+    if re.search(r"2\d{3}", name):
+        archive = annual_archive_resource(name, url, size, md5_hash)
+    else:
+        archive = minimal_archiver(name, url, size, md5_hash)
+
+    return archive

--- a/src/pudl_zenodo_storage/zs/metadata.py
+++ b/src/pudl_zenodo_storage/zs/metadata.py
@@ -12,6 +12,8 @@ UUIDS: dict[str, str] = {
     "epacems": "8bd99e7d-b11a-4bd1-8af0-bccf984dcc43",
     "ferc1": "d3d91c87-c595-49d5-a7f3-e5f5669c8306",
     "ferc2": "894a87fd-cc94-46d1-903a-44be6e77d450",
+    "ferc6": "21d71f60-6073-421a-9208-e4d1adfc4ee2",
+    "ferc60": "a64f9e22-fe9a-4f46-801d-c1a9b5f492b0",
     "ferc714": "f31f0894-639e-4bc2-9b7f-8a84713bcc87",
 }
 


### PR DESCRIPTION
This pull request adds FERC forms 6, 60 to the archiver. It also updates form 714 to handle both yearly XBRL data, and bulk historical CSV data. It also adds a second partition to the FERC resource descriptors to indicate if data is XBRL or DBF based. This is needed to handle overlapping years where both types of data are available.